### PR TITLE
Fix eleven coherence defects across the ancIBD package

### DIFF
--- a/package/ancIBD/__init__.py
+++ b/package/ancIBD/__init__.py
@@ -1,1 +1,10 @@
-pass
+"""ancIBD: Identify IBD segments between pairs of individuals in ancient DNA."""
+
+from importlib.metadata import PackageNotFoundError, version as _version
+
+try:
+    ### Read the version from the installed package metadata, so that
+    ### pyproject.toml stays the single place the version is declared.
+    __version__ = _version("ancIBD")
+except PackageNotFoundError:  # Running from a source tree, not an install
+    __version__ = "unknown"

--- a/package/ancIBD/emission.py
+++ b/package/ancIBD/emission.py
@@ -71,7 +71,7 @@ class HaplotypeSharingEmissions(Emissions):
         p: [l] array of derived genotype probability.
         shared: tuple of length 2 giving the indices of the shared haplotypes"""
         not_shared = [i for i in range(0,4) if i not in shared]
-        assert(len(not_shared)==2 & len(shared)==2)
+        assert(len(not_shared)==2 and len(shared)==2)
         p_hw1 = self.hw_prob_haplo_pp(hts_p[not_shared[0],:], p=p)
         p_hw2 = self.hw_prob_haplo_pp(hts_p[not_shared[1],:], p=p)
         p_shared = self.hw_prob_haplo_share_pp(hts_p[shared[0],:],hts_p[shared[1],:], p=p)
@@ -118,7 +118,7 @@ class HaplotypeSharingEmissions2(Emissions):
         shared: tuple of length 2 giving the indices of the shared haplotypes"""
         ### Sanity Check
         not_shared = [i for i in range(0,4) if i not in shared]
-        assert(len(not_shared)==2 & len(shared)==2) # Sanity Check
+        assert(len(not_shared)==2 and len(shared)==2) # Sanity Check
         
         # Actual Calculation
         p_shared = self.hw_prob_haplo_share_pp(hts_p[shared[0],:],hts_p[shared[1],:], p=p)

--- a/package/ancIBD/genetic_map.py
+++ b/package/ancIBD/genetic_map.py
@@ -1,0 +1,25 @@
+"""Canonical lengths of the human autosomes along the genetic map.
+
+Single source of truth for the genome-wide constants used both when fitting Ne
+(ancIBD.ibd_stats.estimate_Ne) and when plotting karyotypes
+(ancIBD.plot.plot_karyotype), so the two cannot drift apart.
+Lengths are from the Eigenstrat 1240k genetic map.
+"""
+
+### Length of each autosome [in cM], keyed by chromosome number.
+CH_LENGTHS_CM = {1: 286.279, 2: 268.840, 3: 223.361, 4: 214.688,
+                 5: 204.089, 6: 192.040, 7: 187.221, 8: 168.003,
+                 9: 166.359, 10: 181.144, 11: 158.219, 12: 174.679,
+                 13: 125.706, 14: 120.203, 15: 141.860, 16: 134.038,
+                 17: 128.491, 18: 117.709, 19: 107.734, 20: 108.267,
+                 21: 62.786, 22: 74.110}
+
+
+def chrom_length_cm(ch):
+    """Return the genetic length of autosome ch [in cM]."""
+    return CH_LENGTHS_CM[ch]
+
+
+def chrom_length_morgan(ch):
+    """Return the genetic length of autosome ch [in Morgan]."""
+    return CH_LENGTHS_CM[ch] / 100.0

--- a/package/ancIBD/hmm.py
+++ b/package/ancIBD/hmm.py
@@ -64,16 +64,6 @@ def fwd_bkwd_p(e_prob, t_mat,  in_val = 1e-4,
 
 ####################################################
 ####################################################
-### Additional Helper Functions
-
-def print_memory_usage():
-    """Print the current Memory Usage in mB"""
-    process = psutil.Process(os.getpid())
-    mb_usage = process.memory_info().rss / 1e6
-    print(f"Memory Usage: {mb_usage} mB")
-    
-    
-####################################################
 ### Factory method to load the right function
 
 def load_fwd_bwd_func(h_model="FiveState"):

--- a/package/ancIBD/ibd_stats/estimate_Ne.py
+++ b/package/ancIBD/ibd_stats/estimate_Ne.py
@@ -6,6 +6,7 @@ Function to estimate Ne from IBD results
 import numpy as np
 import pandas as pd
 from TTNe.analytic import singlePop_2tp_given_Ne_negLoglik
+from ancIBD.genetic_map import CH_LENGTHS_CM
 from ancIBD.ibd_stats.ibd_sites_stats import get_ibd_stats_unrelated
 
 def fit_Ne_ibd(df, n_pairs, bins = np.arange(8, 30, 0.25), Ne_list = np.arange(100, 20000, 100)):
@@ -18,11 +19,7 @@ def fit_Ne_ibd(df, n_pairs, bins = np.arange(8, 30, 0.25), Ne_list = np.arange(1
     binMidpoint = (bins[1:] + bins[:-1])/2
     histo, _ = np.histogram(100*df['lengthM'], bins=bins)
     
-    ### Hard Coded Human Genome Parameters
-    ch_len_dict = {1:286.279, 2:268.840, 3:223.361, 4:214.688, 5:204.089, 6:192.040, 7:187.221, 8:168.003, 9:166.359, \
-        10:181.144, 11:158.219, 12:174.679, 13:125.706, 14:120.203, 15:141.860, 16:134.038, 17:128.491, 18:117.709, \
-        19:107.734, 20:108.267, 21:62.786, 22:74.110}
-    G = np.array([val for k, val in ch_len_dict.items()]) # Total Genom length
+    G = np.array([val for k, val in CH_LENGTHS_CM.items()]) # Total Genom length
 
     mat = np.zeros(len(Ne_list))
 

--- a/package/ancIBD/loaddata.py
+++ b/package/ancIBD/loaddata.py
@@ -366,7 +366,7 @@ class LoadDict(LoadHDF5Multi):
             p = self.get_p(hts)  # Calculate Mean allele frequency from sample subset                
         
         ### Filter to Valid data
-        if filtering:
+        if self.filtering:
             hts, p, m, bp = self.filter_valid_data(hts, p, m, bp)
         
         self.check_valid_data(hts, p, m)

--- a/package/ancIBD/main.py
+++ b/package/ancIBD/main.py
@@ -87,7 +87,7 @@ class HMM_Full(object):
         """Run Forward Backward algorithm.
         Legacy: Timed version."""
         t = time()
-        htsl, p, r_vec, _ =  self.l_obj.load_all_data()
+        htsl, p, r_vec, bp, samples =  self.l_obj.load_all_data()
         e = time()
         print(f"Runtime Loading: {(e-t)} s")
         
@@ -104,7 +104,7 @@ class HMM_Full(object):
         if full:
             post, fwd, bwd, tot_ll = self.fwd_bwd(e_mat, t_mat, in_val = self.in_val, 
                                                   full=full, output=self.output)
-            self.p_obj.call_roh(r_vec, post)
+            self.p_obj.call_roh(r_vec, bp, post)
             return post, r_vec, fwd, bwd, tot_ll
         else:
             t = time()
@@ -113,7 +113,7 @@ class HMM_Full(object):
             e = time()
             print(f"Runtime HMM calc.: {(e-t)} s")
             t = time()
-            self.p_obj.call_roh(r_vec, post)
+            self.p_obj.call_roh(r_vec, bp, post)
             e = time()
             print(f"Runtime Postprocessing: {(e-t)} s")
             return post, r_vec                                                                    
@@ -146,6 +146,6 @@ class HMM_Full(object):
     
     def reset_print(self):
         """Resets output to console."""
-        sys.stdout = sys.__stdout
+        sys.stdout = sys.__stdout__
         if self.output:
             print("Output was reset to standard console.")

--- a/package/ancIBD/plot/plot_karyotype.py
+++ b/package/ancIBD/plot/plot_karyotype.py
@@ -14,6 +14,7 @@ from matplotlib import gridspec
 import matplotlib.patheffects as pe
 
 #sys.path.insert(0,"/n/groups/reich/hringbauer/git/hapBLOCK/python3/")  # hack to get development package first in path
+from ancIBD.genetic_map import chrom_length_morgan
 from ancIBD.ibd_stats.funcs import give_sub_df
 
 ###########################################################################
@@ -21,17 +22,12 @@ from ancIBD.ibd_stats.funcs import give_sub_df
 ### The Functions for the Plot
 
 def chrom_length(ch, ch_lengths=[], output=False):
-    """Get and return length of Chromosome ch
+    """Get and return length of Chromosome ch [in Morgan]
     If ch_lengths not given, use default (from Eigenstrat map).
     Atm only do autosomes!"""
     if len(ch_lengths)==0:
-        ch_lengths = [2.86273, 2.688325, 2.232573, 2.145423,
-                      2.040858, 1.920325, 1.871526, 1.680022,
-                      1.66301, 1.809153, 1.582171, 1.746799,
-                      1.257046, 1.202023, 1.41346, 1.340263,
-                      1.284738, 1.177099, 1.077316, 1.082134,
-                      0.627865, 0.740762]
-        return ch_lengths[ch-1]
+        return chrom_length_morgan(ch)
+    return ch_lengths[ch-1]
 
 def load_bad_areas(path="./Data/1000Genomes/Markers/1240k/snp_density.csv", min_snps=50):
     """Load areas of low SNP density, and return list of Dataframes 

--- a/package/ancIBD/postprocessing.py
+++ b/package/ancIBD/postprocessing.py
@@ -10,6 +10,13 @@ import numpy as np
 import pandas as pd
 import os as os
 
+### Default parameters for calling IBD2 segments. Single source of truth:
+### IBD2Postprocessing, the hapBLOCK wrappers in run.py and the ancIBD CLI all
+### take their defaults from here, so they cannot drift apart.
+CUTOFF_POST2 = 0.8          # Cutoff Probability for the IBD2 state
+MIN_CM2_INIT = 0.25         # Min. length of an IBD2 segment before merging [in cM]
+MIN_CM2_AFTER_MERGE = 4.0   # Min. length of an IBD2 segment after merging [in cM]
+
 class PostProcessing(object):
     """Class that can do PostProcessing of HAPSBURG output.
     (for one individual). Sometimes post-processing is done outside that,
@@ -244,10 +251,10 @@ class NoPostProcessing(PostProcessing):
         pass
 
 class IBD2Postprocessing(PostProcessing):
-    min_cm2_init = 1.0
-    min_cm2_after_merge = 2.0
+    min_cm2_init = MIN_CM2_INIT
+    min_cm2_after_merge = MIN_CM2_AFTER_MERGE
     cutoff_post1 = 0.99    # Cutoff Probability for IBD1 state
-    cutoff_post2 = 0.975    # Cutoff Probability for IBD2 state
+    cutoff_post2 = CUTOFF_POST2    # Cutoff Probability for IBD2 state
 
     def create_df(self, starts, ends, starts_map, ends_map, 
               l, l_map, starts_bp, ends_bp, ch, min_cm, iid1, iid2, segment_type="IBD1"):

--- a/package/ancIBD/run.py
+++ b/package/ancIBD/run.py
@@ -14,7 +14,9 @@ import sys as sys
 import os as os
 import warnings
 
+from ancIBD import __version__
 from ancIBD.main import HMM_Full  # To run the main plotting.
+from ancIBD.postprocessing import CUTOFF_POST2, MIN_CM2_INIT, MIN_CM2_AFTER_MERGE
 from ancIBD.plot.plot_posterior import plot_posterior, plot_posterior_IBD2 # to plot the posterior.
 from ancIBD.IO.h5_load import get_opp_homos_f, get_opp_homos_X, get_diff_gt_f
 
@@ -24,7 +26,8 @@ def hapBLOCK_chrom(folder_in="./data/hdf5/1240k_v43/ch", iids = ["", ""],
                    t_model="standard", p_model='hapROH', p_col="variants/AF_ALL", 
                    ibd_in=1, ibd_out=10, ibd_jump=400, ibd_jump2=0.5, min_cm=2, min_error=1e-3,
                    cutoff_post=0.99, max_gap=0.0075,
-                   IBD2=False, cutoff_post2=0.8, min_cm2_init=0.25, min_cm2_after_merge=4.0):
+                   IBD2=False, cutoff_post2=CUTOFF_POST2, min_cm2_init=MIN_CM2_INIT,
+                   min_cm2_after_merge=MIN_CM2_AFTER_MERGE):
     """Run IBD for ONE pair of Individuals.
     folder_in: hdf5 path up to chromosome.
     iids: List of IIDs to compare [length 2]
@@ -92,7 +95,8 @@ def hapBLOCK_chroms(folder_in="./data/hdf5/1240k_v43/ch", iids = [], run_iids=[]
                    t_model="standard", p_model="hapROH", p_col="variants/AF_ALL", 
                    ibd_in=1, ibd_out=10, ibd_jump=400, ibd_jump2=0.5, min_cm=2,
                    cutoff_post=0.99, max_gap=0.0075, 
-                   IBD2=False, cutoff_post2=0.975, min_cm2_init=1.0, min_cm2_after_merge=2.0,
+                   IBD2=False, cutoff_post2=CUTOFF_POST2, min_cm2_init=MIN_CM2_INIT,
+                   min_cm2_after_merge=MIN_CM2_AFTER_MERGE,
                    mask=""):
     """Run IBD for list of Individuals, and saves their IBD csv into a single 
     output folder.
@@ -204,8 +208,8 @@ def hapBLOCK_times(folder_in="./data/hdf5/1240k_v43/ch", iids = [], run_iids=[],
     
     ### Load all data
     h.l_obj.set_params(filtering=False) # To not batch filter data
-    htsl, p, r_vec, samples =  h.l_obj.load_all_data()
-    
+    htsl, p, r_vec, bp, samples =  h.l_obj.load_all_data()
+
     t2 = time()
     
     ### Load transition matrix
@@ -227,7 +231,7 @@ def hapBLOCK_times(folder_in="./data/hdf5/1240k_v43/ch", iids = [], run_iids=[],
         post =  h.fwd_bwd(e_mat, t_mat[idx,:,:], in_val =  h.in_val, 
                             full=False, output= h.output)
 
-        df_ibd, _, _ = h.p_obj.call_roh(r_vec[idx], post, iid1, iid2)
+        df_ibd, _, _ = h.p_obj.call_roh(r_vec[idx], bp[idx], post, iid1, iid2)
         df_ibds.append(df_ibd)
     
     df_ibds = pd.concat(df_ibds)
@@ -274,7 +278,7 @@ def run_plot_pair(path_h5="/n/groups/reich/hringbauer/git/hapBLOCK/data/hdf5/124
         
     if plot:
         if len(title)==0:
-            title = f"ancIBD v0.5, {iids[0]} - {iids[1]}, Chr. {ch}"
+            title = f"ancIBD v{__version__}, {iids[0]} - {iids[1]}, Chr. {ch}"
             
         ### Load the data from the HDF5
         o_homos, m = get_opp_homos_f(iid1=iids[0], iid2=iids[1], 
@@ -293,7 +297,8 @@ def run_plot_pair_IBD2(path_h5="/n/groups/reich/hringbauer/git/hapBLOCK/data/hdf
                   plot=False, path_fig="", output=False, exact=True,
                   ibd_in=1, ibd_out=10, ibd_jump=400, min_cm1=8, 
                   cutoff_post=0.99, max_gap=0.0075, p_col="variants/AF_ALL",
-                  cutoff_post2=0.8, min_cm2_init=0.25, min_cm2_after_merge=4.0, 
+                  cutoff_post2=CUTOFF_POST2, min_cm2_init=MIN_CM2_INIT,
+                  min_cm2_after_merge=MIN_CM2_AFTER_MERGE,
                   title="", state=0, return_post=False):
     """Run and plot IBD for pair of Individuals.
     folder_out: Where to save the hapBLOCK output to
@@ -514,7 +519,7 @@ def run_plot_pair_X(folder_in="", iids = ["", ""], ploidy=(2,2),
         
     if plot:
         if len(title)==0:
-            title = f"ancIBD v0.5, {iids[0]} - {iids[1]}, Chr. X"
+            title = f"ancIBD v{__version__}, {iids[0]} - {iids[1]}, Chr. X"
         o_homos, m = get_opp_homos_X(folder_in + "X.h5", iid1=iids[0], iid2=iids[1], ploidy=ploidy, cutoff=gp_filter, output=output, exact=exact)
         print(f"Plotting {len(r_vec)} markers")
         print(f'# of oppo homos: {np.sum(o_homos)}')

--- a/package/ancIBD/run_ancIBD.py
+++ b/package/ancIBD/run_ancIBD.py
@@ -2,6 +2,7 @@
 
 import argparse
 from ancIBD.run import hapBLOCK_chroms
+from ancIBD.postprocessing import CUTOFF_POST2, MIN_CM2_INIT, MIN_CM2_AFTER_MERGE
 from ancIBD.IO.prepare_h5 import vcf_to_1240K_hdf
 from pathlib import Path
 import h5py
@@ -18,7 +19,7 @@ def main():
                         But please make sure that the hdf5 file has suffix ch{chromosome number}.h5 (e.g, test.ch20.h5).")
     parser.add_argument('--ch', action="store", dest="ch", type=int, required=True, help='chromosome number (1-22).')
     parser.add_argument('--marker_path', action="store", dest="marker_path", type=str, required=False, default="", help='path to the marker file')
-    parser.add_argument('--map_path', action="store", dest="map_path", type=str, required=False, help='path to the map file')
+    parser.add_argument('--map_path', action="store", dest="map_path", type=str, required=False, default="", help='path to the map file')
     parser.add_argument('--af_path', action="store", dest="af_path", type=str, required=False, default="", help='path to the allele frequency file (optional)')
     parser.add_argument('--af_column', action='store', dest='af_column', type=str, required=False, default='', help='column name of the allele frequency in the hdf5. For example, "variants/AF_ALL" or "variants/AF_SAMPLE".')
     parser.add_argument('--out', action="store", dest="out", type=str, required=False, help='output folder to store IBD results and the intermediary .hdf5 file. If not specified, the results will be stored in the same folder as the input vcf file.')
@@ -30,9 +31,9 @@ def main():
     parser.add_argument('--iid', action="store", dest="iid", type=str, required=False, help="A list of sample iids to run ancIBD on (each line contains one sample IID). The sample list must match the sample name in the provided vcf file. If unspecified, ancIBD will run on all samples in the vcf file")
     parser.add_argument('--pair', action="store", dest="pair", type=str, required=False, help="A list of sample pairs to run ancIBD on (each line contains two sample IIDs separated by a whitespace). The sample list must match the sample name in the provided vcf file, and, if --iid is specified, all samples must also appear in the iid file. If unspecified, ancIBD will run on all pairs of samples in the vcf file")
     parser.add_argument('--IBD2', action="store_true", dest="IBD2", required=False, help="If specified, ancIBD will enable the detection of IBD2 segments. Default is false.")
-    parser.add_argument('--post2', action='store', dest='post2', type=float, required=False, default=0.8, help='posterior probability cutoff for IBD2 segments. Default is 0.975.')
-    parser.add_argument('--min_cm2_init', action='store', dest='min_cm2_init', type=float, required=False, default=0.25, help='minimum length of IBD2 segment in cM before merging. Default is 1.0.')
-    parser.add_argument('--min_cm2_after_merge', action='store', dest='min_cm2_after_merge', type=float, required=False, default=4.0, help='minimum length of IBD2 segment in cM after merging. Default is 2.0.')
+    parser.add_argument('--post2', action='store', dest='post2', type=float, required=False, default=CUTOFF_POST2, help=f'posterior probability cutoff for IBD2 segments. Default is {CUTOFF_POST2}.')
+    parser.add_argument('--min_cm2_init', action='store', dest='min_cm2_init', type=float, required=False, default=MIN_CM2_INIT, help=f'minimum length of IBD2 segment in cM before merging. Default is {MIN_CM2_INIT}.')
+    parser.add_argument('--min_cm2_after_merge', action='store', dest='min_cm2_after_merge', type=float, required=False, default=MIN_CM2_AFTER_MERGE, help=f'minimum length of IBD2 segment in cM after merging. Default is {MIN_CM2_AFTER_MERGE}.')
     parser.add_argument('--mask', action='store', dest='mask', type=str, required=False, default="", help='Mask file to mask out regions for IBD calling.')
     parser.add_argument('-v', '--verbose', action='store_true', dest='verbose', required=False, help='turn on verbose mode')
     args = parser.parse_args()

--- a/package/ancIBD/run_ancIBDX.py
+++ b/package/ancIBD/run_ancIBDX.py
@@ -18,8 +18,8 @@ def main():
                         Only one of --vcf and --h5 should be specified.\
                         But please make sure that the hdf5 file has suffix ch{chromosome number}.h5 (e.g, test.ch20.h5).")
     parser.add_argument('--ch', action="store", dest="ch", type=str, required=False, default='X', help='chromosome name, default by X.')
-    parser.add_argument('--marker_path', action="store", dest="marker_path", type=str, required=False, help='path to the marker file')
-    parser.add_argument('--map_path', action="store", dest="map_path", type=str, required=False, help='path to the map file')
+    parser.add_argument('--marker_path', action="store", dest="marker_path", type=str, required=False, default="", help='path to the marker file')
+    parser.add_argument('--map_path', action="store", dest="map_path", type=str, required=False, default="", help='path to the map file')
     parser.add_argument('--af_path', action="store", dest="af_path", type=str, required=False, default="", help='path to the allele frequency file (optional)')
     parser.add_argument('--af_column', action='store', dest='af_column', type=str, required=False, default='', help='column name of the allele frequency in the hdf5. For example, "variants/AF_ALL" or "variants/AF_SAMPLE".')
     parser.add_argument('--out', action="store", dest="out", type=str, required=False, help='output folder to store IBD results and the intermediary .hdf5 file. If not specified, the results will be stored in the same folder as the input vcf file.')
@@ -63,7 +63,7 @@ def main():
         # create the output folder if it does not already exist
         if os.path.isdir(oDir) is False:
             # create the output folder and its parental folders if they do not exist
-            Path(oDir).mkdir(parents=True)
+            Path(oDir).mkdir(parents=True, exist_ok=True)
 
     if args.vcf is not None:
         path_vcf_1240k = os.path.join(f"{oDir}", f"{prefix}.1240k.vcf") # temporary vcf file
@@ -82,7 +82,8 @@ def main():
                  col_sample_af = col_sample_af,
                  buffer_size=20000, chunk_width=8, chunk_length=20000,
                  ch=ch)
-        os.remove(path_vcf_1240k) # remove intermediary vcf files
+        if len(args.marker_path) > 0:
+            os.remove(path_vcf_1240k) # remove intermediary vcf files
     else:
         path_h5 = args.h5
 


### PR DESCRIPTION
Fixes eleven defects found by a coherence review of the package. Each one either makes a documented code path runnable again, or removes a second home for a fact that had already drifted.

Every fix is verified by exercising the actual code path, not just a compile check — the package was installed into a clean venv (Cython extension included) and driven from there.

## Latent crashes

| File | Defect |
|---|---|
| `loaddata.py:369` | `LoadDict.load_all_data` read a bare `filtering` instead of `self.filtering`, raising `NameError` on **every** call. This killed the `l_model="dict"` path entirely — a path the change log advertises and `notebook/tests/unit_tests.ipynb` uses. |
| `main.py:149` | `reset_print` used `sys.__stdout` (missing trailing `__`) → `AttributeError`. |
| `main.py:107,116`, `run.py:230` | Three legacy call sites still used the pre-`bp` `call_roh` signature, silently binding `post` into the `bp` slot. `hapBLOCK_times` additionally unpacked 4 values from `load_all_data`, which returns 5. |
| `run_ancIBDX.py:21,22`, `run_ancIBD.py:21` | `--marker_path` / `--map_path` had no `default=""`, so omitting them hit `len(None)` inside `vcf_to_1240K_hdf`. |
| `run_ancIBDX.py:85` | The intermediate VCF was removed unconditionally, even when `marker_path` was empty and it was therefore never created → `FileNotFoundError`. The autosome CLI already guarded this. |

## Facts with more than one home

**IBD2 defaults** lived in four places with three different value sets, and the CLI help text agreed with none of them:

| Home | `post2` | `min_cm2_init` | `min_cm2_after_merge` |
|---|---|---|---|
| `IBD2Postprocessing` | 0.975 | 1.0 | 2.0 |
| `hapBLOCK_chroms` | 0.975 | 1.0 | 2.0 |
| `hapBLOCK_chrom` | 0.8 | 0.25 | 4.0 |
| CLI `default=` | 0.8 | 0.25 | 4.0 |
| CLI `help=` text | *"0.975"* | *"1.0"* | *"2.0"* |

Commit 2d9a21e deliberately moved to `0.8/0.25/4.0` but only updated two of the four homes, so those are taken as canonical. They now live in `postprocessing.py`; `run.py` and the CLI reference them, and the help text is generated from the default so it cannot go stale again.

**Genetic map lengths** were hardcoded in both `plot_karyotype.py` (Morgan) and `estimate_Ne.py` (cM) and had already drifted — chr1 was 286.273 vs 286.279 cM. Both now share one table in a new `genetic_map.py`, using the `estimate_Ne` values so **Ne estimates are bit-for-bit unchanged**; karyotype plots shift by well under a pixel.

**Version** was hardcoded as a stale `"v0.5"` in two plot titles, while `pyproject.toml` said 0.9. `__version__` is now read from package metadata, leaving `pyproject.toml` as the only declaration.

## Also

- `emission.py:74,121` — `assert(len(a)==2 & len(b)==2)` parsed as bit-masking rather than a conjunction, so the check never fired. It now rejects a wrong-length `shared`.
- `hmm.py:69-73` — removed `print_memory_usage`, which referenced `psutil` and `os` without importing either. `cfunc.pyx` keeps its own working copy.
- `plot_karyotype.py` — `chrom_length` returned `None` when passed explicit `ch_lengths`, contradicting its docstring. No caller used that branch.

## One behaviour change to be aware of

`hapBLOCK_chroms()` **called from Python** without explicit IBD2 arguments now uses `0.8/0.25/4.0` rather than `0.975/1.0/2.0`. CLI behaviour is unchanged, since it already passed these values explicitly.

## Not included

- Hardcoded `/n/groups/reich/...` cluster paths as default arguments on ~15 public functions — deliberately left for a separate change, since making them required is an API break.
- `package/legacy_setup.py` still declares `version="0.7"`, a third stale copy. It is referenced nowhere and unused for builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)